### PR TITLE
Label normal surface packets with their coord system

### DIFF
--- a/qtui/src/packets/surfacescreator.cpp
+++ b/qtui/src/packets/surfacescreator.cpp
@@ -192,7 +192,7 @@ regina::Packet* SurfacesCreator::createPacket(regina::Packet* parent,
             regina::NS_ALG_DEFAULT, &tracker);
 
         if (dlg.run()) {
-            ans->setLabel("Vertex normal surfaces");
+            ans->setLabel(Coordinates::name(coordSystem, true));
             return ans;
         } else {
             delete ans;
@@ -214,7 +214,7 @@ regina::Packet* SurfacesCreator::createPacket(regina::Packet* parent,
             regina::NS_ALG_DEFAULT, &tracker);
 
         if (dlg.run()) {
-            ans->setLabel("Fundamental normal surfaces");
+            ans->setLabel(Coordinates::name(coordSystem, true));
             return ans;
         } else {
             delete ans;


### PR DESCRIPTION
Issue #10 

Note that this doesn't touch the engine, just the qtui. It just calls Coordinates::name(). We can't use the templated functions from the engine as NameFunction() and similar are not exposed (and I think rightly so).

There is still the question of whether to leave the bracketed "(tri-quad)" in the labels. Currently I have left them as it is easiest that way. If we want, we can just strip out anything in brackets but I don't know how useful that is.