### PR TITLE
Adds include of <functional> so builds with gcc 7

### DIFF
--- a/engine/triangulation/dim3/triangulation3.h
+++ b/engine/triangulation/dim3/triangulation3.h
@@ -44,6 +44,7 @@
 
 #include <map>
 #include <memory>
+#include <functional>
 #include <vector>
 #include <set>
 


### PR DESCRIPTION
According to the [gcc 7 porting guide](https://gcc.gnu.org/gcc-7/porting_to.html), the standard library header `<memory>` no longer implicitly pulls in `<functional>`.  This one line change includes the latter so that `std::bind` and `std::function` are defined as needed.