### PR TITLE
Using __all__ in __init__.py to avoid "from regina import *" overwriting "open"

### DIFF
--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -27,7 +27,16 @@
 #
 
 import sys, os
+from . import engine
 from .engine import *
+
+# Typing "from regina import *" is not supposed to import "open".
+# To achieve this, we skip it in __all__.
+__all__ = (
+    [ name for name in engine.__dict__.keys()
+      if name != 'open' and not name.startswith('_') ] +
+    [ 'reginaSetup' ])
+    
 
 def reginaSetup(quiet = False, readline = True, banner = False,
                 snappyPath = True, namespace = None, builtinOpen = True):


### PR DESCRIPTION
"from regina import *" should not overwrite the builtin "open".
Currently it does and there is a cumbersome work around in reginaSetup to reconstruct the builtin "open" after "from regina import *".
With this change, __all__ is used to avoid overwriting the builtin "open". This is more elegant and allows the convenience of "from regina import *" in a python interpreter not initialized by the GUI.

In the future, we can actually simply "reginaSetup" and remove the arguments namespace and builtinOpen (and actually "quiet" as well since it is not used).
