### PR TITLE
Adding tweaks for better compatibility with Sage

### DIFF
--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -65,8 +65,8 @@ try:
     GlobalDirs.setDirs(
         GlobalDirs.home(),
         GlobalDirs.pythonModule(),
-        _pyCensusPath)
-except:
+        _pyCensusPath[0])
+except ImportError:
     pass
 
 # Adds some additional pure Python methods to some of Regina's classes.

--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -58,6 +58,17 @@ __all__ = (
 if _within_sage:
     engine._registerIntFromPyIndex()
 
+try:
+    # In sageRegina, the census files are supplied differently,
+    # set the location here.
+    from .pyCensus import __path__ as _pyCensusPath
+    GlobalDirs.setDirs(
+        GlobalDirs.home(),
+        GlobalDirs.pythonModule(),
+        _pyCensusPath)
+except:
+    pass
+
 # Adds some additional pure Python methods to some of Regina's classes.
 from . import purePyMethods
 del purePyMethods

--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -53,7 +53,11 @@ __all__ = (
     [ name for name in engine.__dict__.keys()
       if not name in names_to_avoid and not name.startswith('_') ] +
     [ 'reginaSetup' ])
-    
+
+# Make boost::python work with Sage Integer's.
+if _within_sage:
+    engine._registerIntFromPyIndex()
+
 # Adds some additional pure Python methods to some of Regina's classes.
 from . import purePyMethods
 del purePyMethods

--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -26,6 +26,9 @@
 # MA 02110-1301, USA.
 #
 
+# Needs to be first
+from __future__ import print_function
+
 try:
     # SageRegina has some weirdness where "import engine" gives
     # an error if not preceeded by "import sage.all"
@@ -150,7 +153,7 @@ def reginaSetup(quiet = False, readline = True, banner = False,
                     sys.path.append(snappyLib + '/lib-dynload')
 
     if banner:
-        print engine.welcome()
+        print(engine.welcome())
 
     if builtinOpen and namespace:
         namespace['open'] = __builtins__['open']

--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -26,15 +26,32 @@
 # MA 02110-1301, USA.
 #
 
+try:
+    # SageRegina has some weirdness where "import engine" gives
+    # an error if not preceeded by "import sage.all"
+    # Needs some investigation, doing this as work-around for now.
+    import sage.all
+    _within_sage = True
+except:
+    _within_sage = False
+
 import sys, os
 from . import engine
 from .engine import *
 
-# Typing "from regina import *" is not supposed to import "open".
-# To achieve this, we skip it in __all__.
+# Typing "from regina import *" should not override certain
+# names. This always applies to the built-in "open".
+names_to_avoid = set(['open'])
+if _within_sage:
+    # The Sage preparser adds "Integer" and relies on the name
+    # being bound to a Sage integer. If we override it, Sage
+    # breaks in multiple ways.
+    names_to_avoid.update(['Integer'])
+
+# We skip names_to_avoid in __all__.
 __all__ = (
     [ name for name in engine.__dict__.keys()
-      if name != 'open' and not name.startswith('_') ] +
+      if not name in names_to_avoid and not name.startswith('_') ] +
     [ 'reginaSetup' ])
     
 # Adds some additional pure Python methods to some of Regina's classes.

--- a/python/testsuite/alltypes.test
+++ b/python/testsuite/alltypes.test
@@ -31,6 +31,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 import re
 
 regex = re.compile("^<class 'regina\\.engine\\.(.+)'>$")
@@ -38,18 +40,18 @@ regex = re.compile("^<class 'regina\\.engine\\.(.+)'>$")
 def classInfo(name, object):
     m = regex.match(str(object))
     if not m:
-        print name, ': ERROR - could not determine real class name.'
+        print(name, ': ERROR - could not determine real class name.')
     else:
         realName = m.group(1)
         if realName == name:
-            print name, ': class'
+            print(name, ': class')
             try:
-                print 'Equality type :', object.equalityType
+                print('Equality type :', object.equalityType)
             except:
-                print 'ERROR: No equality type'
+                print('ERROR: No equality type')
         else:
-            print name, ': typedef -> ', realName
-    print
+            print(name, ': typedef -> ', realName)
+    print()
 
 def enumInfo(name, object):
     # print name, ': enum'

--- a/python/testsuite/embeddings.test
+++ b/python/testsuite/embeddings.test
@@ -31,9 +31,11 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 def doit(list):
 	for f in list:
-		print f
+		print(f)
 
 t = Triangulation2()
 s = t.newSimplex()

--- a/python/testsuite/equality.test
+++ b/python/testsuite/equality.test
@@ -31,9 +31,11 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
-print AbelianGroup.equalityType
-print Integer.equalityType
-print Triangulation3.equalityType
+from __future__ import print_function
+
+print(AbelianGroup.equalityType)
+print(Integer.equalityType)
+print(Triangulation3.equalityType)
 
 # Test == and != for objects that are equal by value but have different
 # underlying C++ pointers.
@@ -41,51 +43,51 @@ print Triangulation3.equalityType
 
 # Cases that should be reported as equal (by value):
 
-print 'Integer:'
+print('Integer:')
 a = Integer(3)
 b = Integer(3)
-print a == b, a != b
+print(a == b, a != b)
 
-print 'AbelianGroup:'
+print('AbelianGroup:')
 a = AbelianGroup()
 b = AbelianGroup()
-print a == b, a != b
+print(a == b, a != b)
 
 # Cases that should be reported as different (by C++ reference):
 
-print 'Triangulation3:'
+print('Triangulation3:')
 a = Triangulation3()
 b = Triangulation3()
-print a == b, a != b
+print(a == b, a != b)
 
-print 'GroupPresentation:'
+print('GroupPresentation:')
 a = GroupPresentation()
 b = GroupPresentation()
-print a == b, a != b
+print(a == b, a != b)
 
 # Test == and != for objects that have the same underlying C++ pointers,
 # but different python wrappers.
 # In all cases these objects should be reported as equal.
 
-print 'Triangulation3:'
+print('Triangulation3:')
 a = Triangulation3()
 b = a.root()
-print a == b, a != b
+print(a == b, a != b)
 
-print 'Tetrahedron3:'
+print('Tetrahedron3:')
 t = Triangulation3()
 a = t.newTetrahedron()
 b = t.tetrahedron(0)
-print a == b, a != b
+print(a == b, a != b)
 
-print 'AbelianGroup:'
+print('AbelianGroup:')
 t = Example3.lens(8,3)
 a = t.homology()
 b = t.homology()
-print a == b, a != b
+print(a == b, a != b)
 
-print 'GroupPresentation:'
+print('GroupPresentation:')
 t = Example3.lens(8,3)
 a = t.fundamentalGroup()
 b = t.fundamentalGroup()
-print a == b, a != b
+print(a == b, a != b)

--- a/python/testsuite/euler.test
+++ b/python/testsuite/euler.test
@@ -31,17 +31,19 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 def printEuler(t, name):
-	print t.eulerCharTri(), t.eulerCharManifold(), \
-		'---', name
+	print(t.eulerCharTri(), t.eulerCharManifold(), \
+		'---', name)
 
 	# Consistency check, while we're here.
 	eHom = regina.HomologicalData(t).eulerChar()
 	if eHom != t.eulerCharManifold():
-		print 'ERROR: Triangulation3::eulerCharManifold() and'
-		print '       HomologicalData.eulerChar() disagree!'
+		print('ERROR: Triangulation3::eulerCharManifold() and')
+		print('       HomologicalData.eulerChar() disagree!')
 
-print 'Euler characteristics for triangulation vs compact manifold:'
+print('Euler characteristics for triangulation vs compact manifold:')
 
 # Empty:
 printEuler(regina.Triangulation3(), "Empty triangulation")

--- a/python/testsuite/facenumbering.test
+++ b/python/testsuite/facenumbering.test
@@ -31,48 +31,50 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 for i in range(6):
     p = Face5_0.ordering(i)
-    print i, p, Face5_0.faceNumber(p)
-print
+    print(i, p, Face5_0.faceNumber(p))
+print()
 for i in range(15):
     p = Face5_1.ordering(i)
-    print i, p, Face5_1.faceNumber(p)
-print
+    print(i, p, Face5_1.faceNumber(p))
+print()
 for i in range(20):
     p = Face5_2.ordering(i)
-    print i, p, Face5_2.faceNumber(p)
-print
+    print(i, p, Face5_2.faceNumber(p))
+print()
 for i in range(15):
     p = Face5_3.ordering(i)
-    print i, p, Face5_3.faceNumber(p)
-print
+    print(i, p, Face5_3.faceNumber(p))
+print()
 for i in range(6):
     p = Face5_4.ordering(i)
-    print i, p, Face5_4.faceNumber(p)
-print
+    print(i, p, Face5_4.faceNumber(p))
+print()
 
 for i in range(7):
     p = Face6_0.ordering(i)
-    print i, p, Face6_0.faceNumber(p)
-print
+    print(i, p, Face6_0.faceNumber(p))
+print()
 for i in range(21):
     p = Face6_1.ordering(i)
-    print i, p, Face6_1.faceNumber(p)
-print
+    print(i, p, Face6_1.faceNumber(p))
+print()
 for i in range(35):
     p = Face6_2.ordering(i)
-    print i, p, Face6_2.faceNumber(p)
-print
+    print(i, p, Face6_2.faceNumber(p))
+print()
 for i in range(35):
     p = Face6_3.ordering(i)
-    print i, p, Face6_3.faceNumber(p)
-print
+    print(i, p, Face6_3.faceNumber(p))
+print()
 for i in range(21):
     p = Face6_4.ordering(i)
-    print i, p, Face6_4.faceNumber(p)
-print
+    print(i, p, Face6_4.faceNumber(p))
+print()
 for i in range(7):
     p = Face6_5.ordering(i)
-    print i, p, Face6_5.faceNumber(p)
-print
+    print(i, p, Face6_5.faceNumber(p))
+print()

--- a/python/testsuite/file.test
+++ b/python/testsuite/file.test
@@ -31,6 +31,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
 
 # Fetch the python/testsuite path in the source tree, since we will need
 # to access external files.
@@ -43,24 +44,24 @@ else:
 # A routine that performs essentially the same tasks as regfiledump.
 def dump(tree):
 	if tree == None:
-		print 'ERROR: Null packet tree.'
+		print('ERROR: Null packet tree.')
 		return
 
 	p = tree
 	while p != None:
-		print '************************************************************'
-		print '*'
-		print '* Label: ' + p.label()
-		print '* Type: ' + p.typeName()
+		print('************************************************************')
+		print('*')
+		print('* Label: ' + p.label())
+		print('* Type: ' + p.typeName())
 		if p.parent() == None:
-			print '* Parent: (none)'
+			print('* Parent: (none)')
 		else:
-			print '* Parent: ' + p.parent().label()
-		print '*'
-		print '************************************************************'
-		print
-		print p.detail()
-		print
+			print('* Parent: ' + p.parent().label())
+		print('*')
+		print('************************************************************')
+		print()
+		print(p.detail())
+		print()
 
 		p = p.nextTreePacket()
 

--- a/python/testsuite/generic.test
+++ b/python/testsuite/generic.test
@@ -31,6 +31,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
 
 def product1(triClass, dim, permClass):
     tri = triClass()
@@ -49,14 +50,14 @@ def product2(triClass, dim, permClass):
     return tri
 
 def dump(tri):
-    print 'Triangulation:', tri.label()
-    print
-    print 'Connected:', tri.isConnected()
-    print 'Orientable:', tri.isOrientable()
-    print 'Oriented:', tri.isOrientable()
-    print 'Boundary facets:', tri.countBoundaryFacets()
-    print
-    print tri.detail()
+    print('Triangulation:', tri.label())
+    print()
+    print('Connected:', tri.isConnected())
+    print('Orientable:', tri.isOrientable())
+    print('Oriented:', tri.isOrientable())
+    print('Boundary facets:', tri.countBoundaryFacets())
+    print()
+    print(tri.detail())
 
 def testDim(triClass, dim, permClass):
     dump(product1(triClass, dim, permClass))

--- a/python/testsuite/groups.test
+++ b/python/testsuite/groups.test
@@ -31,6 +31,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 import string
 
 def vecToString(v):
@@ -57,35 +59,35 @@ def makeHom(domain, range, rows, cols, values):
 		domain, range, makeMatrix(rows, cols, values))
 
 def groupStats(g):
-	print "------------------------"
-	print "New marked abelian group"
-	print "------------------------"
-	print
-	print 'Group:', g
+	print("------------------------")
+	print("New marked abelian group")
+	print("------------------------")
+	print()
+	print('Group:', g)
 
-	print 'Free generators:'
+	print('Free generators:')
 	for i in range(g.rank()):
-		print str(i) + ':', vecToString(g.freeRep(i))
-	print 'Torsion generators:'
+		print(str(i) + ':', vecToString(g.freeRep(i)))
+	print('Torsion generators:')
 	for i in range(g.countInvariantFactors()):
-		print str(i) + ':', vecToString(g.torsionRep(i))
+		print(str(i) + ':', vecToString(g.torsionRep(i)))
 
 	# Nothing else to say.
-	print
+	print()
 
 def homStats(h):
-	print "----------------"
-	print "New homomorphism"
-	print "----------------"
-	print
-	print 'Domain:', h.domain()
-	print 'Range:', h.range()
-	print 'Kernel:', h.kernel()
-	print 'Cokernel:', h.cokernel()
-	print 'Image:', h.image()
+	print("----------------")
+	print("New homomorphism")
+	print("----------------")
+	print()
+	print('Domain:', h.domain())
+	print('Range:', h.range())
+	print('Kernel:', h.kernel())
+	print('Cokernel:', h.cokernel())
+	print('Image:', h.image())
 
 	# Nothing else to say.
-	print
+	print()
 
 
 # Z + Z_6:
@@ -111,18 +113,18 @@ homStats(makeHom(g2, g1,
 	5, 5, [-3,0,0,-1,1,-3,0,0,-1,1,3,0,0,1,-1,0,0,0,0,0,3,0,0,1,-1]))
 
 # Some playing with snfRep():
-print "------------------------------------"
-print "Miscellaneous vector representations"
-print "------------------------------------"
-print
+print("------------------------------------")
+print("Miscellaneous vector representations")
+print("------------------------------------")
+print()
 
-print vecToString(g1.snfRep([-6,0,0,0,5]))
-print vecToString(g1.snfRep([-6,0,0,0,6]))
-print vecToString(g1.snfRep([-4,2,-2,0,4]))
-print vecToString(g1.snfRep([-8,-2,2,0,8]))
-print vecToString(g1.snfRep([0,6,-6,0,0]))
+print(vecToString(g1.snfRep([-6,0,0,0,5])))
+print(vecToString(g1.snfRep([-6,0,0,0,6])))
+print(vecToString(g1.snfRep([-4,2,-2,0,4])))
+print(vecToString(g1.snfRep([-8,-2,2,0,8])))
+print(vecToString(g1.snfRep([0,6,-6,0,0])))
 
-print vecToString(g2.snfRep([0,-3,-1,3,0]))
-print vecToString(g2.snfRep([0,-3,-1,3,1]))
-print vecToString(g2.snfRep([-3,0,-1,3,1]))
+print(vecToString(g2.snfRep([0,-3,-1,3,0])))
+print(vecToString(g2.snfRep([0,-3,-1,3,1])))
+print(vecToString(g2.snfRep([-3,0,-1,3,1])))
 

--- a/python/testsuite/hypersurfaces.test
+++ b/python/testsuite/hypersurfaces.test
@@ -31,14 +31,16 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 import string
 
 def dumpSurfaces(name, slist):
-	print "-------------------------------"
-	print slist.triangulation().label()
-	print name
-	print "-------------------------------"
-	print
+	print("-------------------------------")
+	print(slist.triangulation().label())
+	print(name)
+	print("-------------------------------")
+	print()
 
 	# Dump the hypersurfaces in sort order, since we don't really mind if the
 	# ordering changes between releases.
@@ -47,10 +49,10 @@ def dumpSurfaces(name, slist):
 	# Let the text headers appear up top.
 	surfaces.reverse()
 	for s in surfaces:
-		print s
+		print(s)
 
 	# Nothing else to say.
-	print
+	print()
 
 def surfaceStats(tri):
 	dumpSurfaces('Vertex hypersurfaces (std)',

--- a/python/testsuite/i18n.test
+++ b/python/testsuite/i18n.test
@@ -31,6 +31,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
 
 # Fetch the python/testsuite path in the source tree, since we will need
 # to access external files.
@@ -57,36 +58,36 @@ suffixes = [ '', 'a', 'alpha', '.', '.0', '.01', '.0.1', '.1',
 for v in oldVersions:
 	for s in suffixes:
 		if regina.versionUsesUTF8(v + s):
-			print 'ERROR: Version ' + v + s + ' claims to use UTF-8.'
+			print('ERROR: Version ' + v + s + ' claims to use UTF-8.')
 
 for v in newVersions:
 	for s in suffixes:
 		if not regina.versionUsesUTF8(v + s):
-			print 'ERROR: Version ' + v + s + ' does not claim to use UTF-8.'
+			print('ERROR: Version ' + v + s + ' does not claim to use UTF-8.')
 
 # Load a file created by an old version of regina.  This file stores it
 # strings as LATIN1, which should be converted to UTF-8 on import.
 i18nOld = regina.open(testpath + '/i18n-latin1.rga')
 if i18nOld != None:
-	print i18nOld.label()
-	print i18nOld.text()
+	print(i18nOld.label())
+	print(i18nOld.text())
 
 # Load a version of the same file created by a newer version of Regina,
 # which stores strings directly in UTF-8.
 i18nNew = regina.open(testpath + '/i18n-utf8.rga')
 if i18nNew != None:
-	print i18nNew.label()
-	print i18nNew.text()
+	print(i18nNew.label())
+	print(i18nNew.text())
 
 # Import a triangulation from SnapPea that uses a subscript character in
 # the triangulation name.
 subscriptImport = SnapPeaTriangulation(testpath + '/O2_1.tri')
 if subscriptImport != None:
-	print subscriptImport.label()
+	print(subscriptImport.label())
 
 # Load a Regina data file with a pre-saved version of this same SnapPea
 # triangulation.
 subscriptLoad = regina.open(testpath + '/O2_1.rga')
 if subscriptLoad != None:
-	print subscriptLoad.firstChild().label()
+	print(subscriptLoad.firstChild().label())
 

--- a/python/testsuite/memory1.test
+++ b/python/testsuite/memory1.test
@@ -31,6 +31,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 def watcher(p):
     # Returns a packet that can be used as a proxy for testing
     # whether or not p has been destroyed.
@@ -42,18 +44,18 @@ def ensureAlive(watcher):
     try:
         watcher.label()
     except:
-        print 'ERROR: ensureAlive failed'
+        print('ERROR: ensureAlive failed')
 
 def ensureDestroyed(watcher):
     try:
         watcher.label()
-        print 'ERROR: ensureDestroyed failed'
+        print('ERROR: ensureDestroyed failed')
     except:
         pass
 
 
 
-print 'Insertion case'
+print('Insertion case')
 c = Container(); cw = watcher(c)
 t = Triangulation3(); t.newTetrahedron(); tw = watcher(t)
 c.insertChildLast(t)
@@ -63,19 +65,19 @@ ensureAlive(cw); ensureAlive(tw)
 c = None
 ensureDestroyed(cw); ensureDestroyed(tw)
 
-print 'Root destruction case'
+print('Root destruction case')
 a = Container(); aw = watcher(a)
 b = Triangulation3(); bw = watcher(b)
 a.insertChildLast(b)
 ensureAlive(aw); ensureAlive(bw)
 a = None
 try:
-    print b
+    print(b)
 except:
     pass
 ensureDestroyed(aw); ensureDestroyed(bw)
 
-print 'Orphan case'
+print('Orphan case')
 p = Container(); pw = watcher(p)
 q = Triangulation3(); qw = watcher(q)
 p.insertChildLast(q)
@@ -92,7 +94,7 @@ ensureDestroyed(qw)
 
 # An example of makeOrphan where we never held the reference to the
 # child in the first place.
-print 'Multiple orphan case'
+print('Multiple orphan case')
 x = Example3.lens(8,3); xw = watcher(x)
 x.connectedSumDecomposition()
 y = x.lastChild(); yw = watcher(y)

--- a/python/testsuite/memory2.test
+++ b/python/testsuite/memory2.test
@@ -31,6 +31,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 def watcher(p):
     c = Container()
     p.insertChildLast(c)
@@ -40,16 +42,16 @@ def ensureAlive(watcher):
     try:
         watcher.label()
     except:
-        print 'ERROR: ensureAlive failed'
+        print('ERROR: ensureAlive failed')
 
 def ensureDestroyed(watcher):
     try:
         watcher.label()
-        print 'ERROR: ensureDestroyed failed'
+        print('ERROR: ensureDestroyed failed')
     except:
         pass
 
-print 'Script variables #1'
+print('Script variables #1')
 a = Container(); aw = watcher(a)
 b = Triangulation3(); b.newSimplex(); bw = watcher(b)
 c = Script(); cw = watcher(c)
@@ -62,7 +64,7 @@ ensureAlive(aw); ensureAlive(bw); ensureAlive(cw)
 a = None
 ensureDestroyed(aw); ensureDestroyed(bw); ensureDestroyed(cw)
 
-print 'Script variables #2'
+print('Script variables #2')
 a = Container(); aw = watcher(a)
 b = Triangulation3(); b.newSimplex(); bw = watcher(b)
 c = Script(); cw = watcher(c)
@@ -77,13 +79,13 @@ ensureAlive(aw); ensureAlive(bw); ensureAlive(cw)
 val = None
 ensureDestroyed(aw); ensureDestroyed(bw); ensureDestroyed(cw)
 
-print 'Example triangulation'
+print('Example triangulation')
 f = ExampleSnapPea.figureEight(); fw = watcher(f)
 ensureAlive(fw)
 f = None
 ensureDestroyed(fw)
 
-print 'Vertex link #1'
+print('Vertex link #1')
 t = Example3.lens(7,1); tw = watcher(t)
 v = t.vertex(0).buildLink(); vw = watcher(v)
 t.insertChildLast(v)
@@ -91,7 +93,7 @@ ensureAlive(tw); ensureAlive(vw)
 t = None
 ensureDestroyed(tw); ensureDestroyed(vw)
 
-print 'Vertex link #2'
+print('Vertex link #2')
 t = Example3.lens(7,1); tw = watcher(t)
 v = t.vertex(0).buildLink(); vw = watcher(v)
 ensureAlive(tw); ensureAlive(vw)
@@ -100,7 +102,7 @@ ensureDestroyed(tw); ensureAlive(vw)
 v = None
 ensureDestroyed(tw); ensureDestroyed(vw)
 
-print 'Vertex link detailed #1'
+print('Vertex link detailed #1')
 t = Example3.lens(7,1); tw = watcher(t)
 v = t.vertex(0).buildLinkDetail(); vw = watcher(v[0])
 t.insertChildLast(v[0])
@@ -108,7 +110,7 @@ ensureAlive(tw); ensureAlive(vw)
 t = None
 ensureDestroyed(tw); ensureDestroyed(vw)
 
-print 'Vertex link detailed #2'
+print('Vertex link detailed #2')
 t = Example3.lens(7,1); tw = watcher(t)
 v = t.vertex(0).buildLinkDetail(); vw = watcher(v[0])
 ensureAlive(tw); ensureAlive(vw)

--- a/python/testsuite/misc.test
+++ b/python/testsuite/misc.test
@@ -31,28 +31,29 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
 
 # The most trivial test: can we talk to the calculation engine at all?
-print regina.testEngine(3)
+print(regina.testEngine(3))
 
 # Some slightly less trivial tests.
 t = regina.Triangulation3()
 t.insertLayeredLensSpace(5,1)
-print t.homology()
+print(t.homology())
 
 # Does equality work correctly?
 a = Perm4(2,3)
 b = Perm4()
 c = Perm4(2,3)
-print a == c, a == b, b == c
-print a != c, a != b, b != c
+print(a == c, a == b, b == c)
+print(a != c, a != b, b != c)
 
 t = regina.Example3.poincareHomologySphere()
 a = t.tetrahedron(0)
 b = t.tetrahedron(1)
 c = t.tetrahedron(0)
-print a == c, a == b, b == c
-print a != c, a != b, b != c
+print(a == c, a == b, b == c)
+print(a != c, a != b, b != c)
 
 # Have we clobbered python's builtin open() function?
-print open
+print(open)

--- a/python/testsuite/orb.test
+++ b/python/testsuite/orb.test
@@ -31,6 +31,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
 
 import sys
 if (len(sys.argv) > 1):
@@ -39,9 +40,9 @@ else:
     testpath = '.'
 
 def testOrb(filename):
-    print 'Orb file:', filename
-    print readOrb(testpath + '/' + filename).detail()
-    print
+    print('Orb file:', filename)
+    print(readOrb(testpath + '/' + filename).detail())
+    print()
 
 testOrb('cube.orb')
 testOrb('dodec.orb')

--- a/python/testsuite/pdf.test
+++ b/python/testsuite/pdf.test
@@ -31,6 +31,7 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
 
 import sys
 if (len(sys.argv) > 1):
@@ -39,12 +40,12 @@ else:
     testpath = '.'
 
 pdf = PDF()
-print 'Null:', pdf.isNull()
-print 'Size:', pdf.size()
+print('Null:', pdf.isNull())
+print('Size:', pdf.size())
 
 pdf = PDF(testpath + '/sample.pdf')
-print 'Null:', pdf.isNull()
-print 'Size:', pdf.size()
+print('Null:', pdf.isNull())
+print('Size:', pdf.size())
 
 # TODO: Export and compare.
 

--- a/python/testsuite/safeheldtype_basic.test
+++ b/python/testsuite/safeheldtype_basic.test
@@ -31,11 +31,13 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
-print "Constructor:"
+from __future__ import print_function
 
-print Container()
+print("Constructor:")
 
-print "Deleting parent:"
+print(Container())
+
+print("Deleting parent:")
 
 c  = Container()
 c1 = Container()
@@ -45,11 +47,11 @@ c.insertChildFirst(c1)
 c = None
 
 try:
-    print c1
+    print(c1)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 
-print "Deleting matriarch:"
+print("Deleting matriarch:")
     
 c  = Container()
 c.insertChildFirst(Container())
@@ -61,16 +63,16 @@ c2 = c.firstChild().firstChild()
 c  = None
 
 try:
-    print c1
+    print(c1)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 
 try:
-    print c2
+    print(c2)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 
-print "Multiple references:"
+print("Multiple references:")
 
 c = Container()
 c1 = Container()
@@ -79,32 +81,32 @@ c2 = Container()
 c.insertChildFirst(c1)
 c1.insertChildFirst(c2)
 
-print c
-print c1
-print c2
+print(c)
+print(c1)
+print(c2)
 
 c1 = None
 
-print c
-print c2
+print(c)
+print(c2)
 
 d = c2.root()
 
 c = None
 
-print c2
+print(c2)
 
 e = c2.root()
 
-print c2
+print(c2)
 
 e = None
 
-print c2
+print(c2)
 
 d = None
 
 try:
-    print c2
+    print(c2)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")

--- a/python/testsuite/safeheldtype_packet.test
+++ b/python/testsuite/safeheldtype_packet.test
@@ -31,19 +31,21 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
-print
-print "-----------------------------------------------------------"
-print "Basic:"
-print
+from __future__ import print_function
 
-print Example3.poincareHomologySphere().isoSig()
-print Text("Hello World")
-print Text("Hello World").text()
+print()
+print("-----------------------------------------------------------")
+print("Basic:")
+print()
 
-print
-print "-----------------------------------------------------------"
-print "Basic container tests:"
-print
+print(Example3.poincareHomologySphere().isoSig())
+print(Text("Hello World"))
+print(Text("Hello World").text())
+
+print()
+print("-----------------------------------------------------------")
+print("Basic container tests:")
+print()
 
 t1 = Triangulation3()
 t2 = Example3.poincareHomologySphere()
@@ -55,98 +57,98 @@ t = Text()
 c = Container()
 c.insertChildFirst(t1)
 
-print c.countChildren()
+print(c.countChildren())
 
-print t1.isoSig()
+print(t1.isoSig())
 t1.newTetrahedron()
 
-print c.firstChild()
-print c.firstChild().isoSig()
+print(c.firstChild())
+print(c.firstChild().isoSig())
 
 t1 = None
 
-print c.firstChild().isoSig()
+print(c.firstChild().isoSig())
 
 temp = c.lastChild()
 
 temp.newTetrahedron()
 
-print temp.isoSig()
+print(temp.isoSig())
 
-print
-print "-----------------------------------------------------------"
-print "Erasing container:"
-print
+print()
+print("-----------------------------------------------------------")
+print("Erasing container:")
+print()
 
 c = None
 
 try:
-    print temp.isoSig()
+    print(temp.isoSig())
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 
-print
-print "-----------------------------------------------------------"
-print "Nested tests:"
-print
+print()
+print("-----------------------------------------------------------")
+print("Nested tests:")
+print()
 
 t2.insertChildFirst(t3)
 t2.insertChildFirst(p)
 p.insertChildLast(t)
 t.setText("Hello World")
 
-print t.text()
+print(t.text())
 
 p.lastChild().setText("Text set")
 
 l = p.firstChild()
 
-print l.text()
+print(l.text())
 
 t2.insertChildAfter(Text("New"), t3)
 
-print t2.countChildren()
-print t2.countDescendants()
+print(t2.countChildren())
+print(t2.countDescendants())
 
 m = l.root()
 
-print m == t2
+print(m == t2)
 
-print m.isoSig()
+print(m.isoSig())
 
 m = None
 
-print p.isNull()
+print(p.isNull())
 
-print p.totalTreeSize()
+print(p.totalTreeSize())
 
 it = t2
 
 while it:
-    print it
+    print(it)
     it = it.nextTreePacket()
 
 t2 = None
 
-print
-print "Erase nested:"
-print "-----------------------------------------------------------"
-print
+print()
+print("Erase nested:")
+print("-----------------------------------------------------------")
+print()
 
 try:
-    print l
+    print(l)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 
 try:
-    print t3
+    print(t3)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 
-print
-print "Make orphan:"
-print "-----------------------------------------------------------"
-print
+print()
+print("Make orphan:")
+print("-----------------------------------------------------------")
+print()
 
 d1 = Triangulation3(); d1.newTetrahedron()
 d2 = Triangulation3(); d2.newTetrahedron(); d2.newTetrahedron()
@@ -154,20 +156,20 @@ d3 = Triangulation3(); d3.newTetrahedron(); d3.newTetrahedron(); d3.newTetrahedr
 d1.insertChildLast(d2)
 d2.insertChildLast(d3)
 
-print d1
-print d2
-print d3
+print(d1)
+print(d2)
+print(d3)
 
 d2.makeOrphan()
-print d1
-print d2
-print d3
+print(d1)
+print(d2)
+print(d3)
 
 try:
     d2 = None
-    print d1
-    print d2
-    print d3
+    print(d1)
+    print(d2)
+    print(d3)
 except RuntimeError:
-    print "Got exception"
+    print("Got exception")
 

--- a/python/testsuite/skeleton.test
+++ b/python/testsuite/skeleton.test
@@ -31,24 +31,26 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 t = Example3.weberSeifert()
-print t.detail()
+print(t.detail())
 for v in t.vertices():
-	print 'Vertex', v.index()
-	print v.detail()
+	print('Vertex', v.index())
+	print(v.detail())
 for e in t.edges():
-	print 'Edge', e.index()
-	print e.detail()
+	print('Edge', e.index())
+	print(e.detail())
 for f in t.triangles():
-	print 'Triangle', f.index()
-	print f.detail()
+	print('Triangle', f.index())
+	print(f.detail())
 
 t = Example2.nonOrientable(3, 1)
-print t.detail()
+print(t.detail())
 for v in t.vertices():
-	print 'Vertex', v.index()
-	print v.detail()
+	print('Vertex', v.index())
+	print(v.detail())
 for e in t.edges():
-	print 'Edge', e.index()
-	print e.detail()
+	print('Edge', e.index())
+	print(e.detail())
 

--- a/python/testsuite/surfaces.test
+++ b/python/testsuite/surfaces.test
@@ -31,21 +31,23 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 import string
 
 def dumpSurfaces(name, slist):
 	if slist == None:
-		print "-------------------------------"
-		print name
-		print 'ENUMERATION FAILED'
-		print "-------------------------------"
-		print
+		print("-------------------------------")
+		print(name)
+		print('ENUMERATION FAILED')
+		print("-------------------------------")
+		print()
 		return
-	print "-------------------------------"
-	print slist.triangulation().label()
-	print name
-	print "-------------------------------"
-	print
+	print("-------------------------------")
+	print(slist.triangulation().label())
+	print(name)
+	print("-------------------------------")
+	print()
 
 	# Dump the surfaces in sort order, since we don't really mind if the
 	# ordering changes between releases.
@@ -54,10 +56,10 @@ def dumpSurfaces(name, slist):
 	# Let the text headers appear up top.
 	surfaces.reverse()
 	for s in surfaces:
-		print s
+		print(s)
 
 	# Nothing else to say.
-	print
+	print()
 
 def surfaceStats(tri):
 	dumpSurfaces('Vertex surfaces (std)',

--- a/python/testsuite/trigeneral.test
+++ b/python/testsuite/trigeneral.test
@@ -31,6 +31,8 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 # For checksums, use the hashlib module if possible (this is new as of
 # python 2.5).  Otherwise fall back to the deprecated md5 module.
 # Thanks to Andreas Wenning for alerting me to this issue.
@@ -53,40 +55,40 @@ def vitalStats(tri):
 	# To guard against accidental changes.
 	old = tri.detail()
 
-	print "-------------------------------"
-	print tri.label()
-	print "-------------------------------"
-	print
-	print tri.detail()
-	print tri.countComponents(), "components"
-	print tri.countBoundaryComponents(), "boundary components"
-	print tri.countTetrahedra(), "tetrahedra"
-	print tri.countTriangles(), "triangles"
-	print tri.countEdges(), "edges"
-	print tri.countVertices(), "vertices"
-	print "2-sphere boundaries:", tri.hasTwoSphereBoundaryComponents()
-	print "Negative ideal boundaries:", tri.hasNegativeIdealBoundaryComponents()
-	print "EC:", tri.eulerCharTri()
-	print "Valid:", tri.isValid()
-	print "Ideal:", tri.isIdeal()
-	print "Standard:", tri.isStandard()
-	print "Boundary Triangles:", tri.hasBoundaryTriangles()
-	print "Closed:", tri.isClosed()
-	print "Orientable:", tri.isOrientable()
-	print "Connected:", tri.isConnected()
-	print
-	print "Fundamental group:", tri.fundamentalGroup().recogniseGroup()
+	print("-------------------------------")
+	print(tri.label())
+	print("-------------------------------")
+	print()
+	print(tri.detail())
+	print(tri.countComponents(), "components")
+	print(tri.countBoundaryComponents(), "boundary components")
+	print(tri.countTetrahedra(), "tetrahedra")
+	print(tri.countTriangles(), "triangles")
+	print(tri.countEdges(), "edges")
+	print(tri.countVertices(), "vertices")
+	print("2-sphere boundaries:", tri.hasTwoSphereBoundaryComponents())
+	print("Negative ideal boundaries:", tri.hasNegativeIdealBoundaryComponents())
+	print("EC:", tri.eulerCharTri())
+	print("Valid:", tri.isValid())
+	print("Ideal:", tri.isIdeal())
+	print("Standard:", tri.isStandard())
+	print("Boundary Triangles:", tri.hasBoundaryTriangles())
+	print("Closed:", tri.isClosed())
+	print("Orientable:", tri.isOrientable())
+	print("Connected:", tri.isConnected())
+	print()
+	print("Fundamental group:", tri.fundamentalGroup().recogniseGroup())
 	# Don't print the full generators and relations for now, since this
 	# is not unique and can therefore lead to spurious test failures.
 	# print tri.fundamentalGroup().detail()
-	print "H1:", tri.homology()
+	print("H1:", tri.homology())
 	if tri.isValid():
-		print "H1Bdry:", tri.homologyBdry()
-		print "H1Rel:", tri.homologyRel()
-		print "H2:", tri.homologyH2()
-		print "H2Z2:", tri.homologyH2Z2(), "Z_2"
+		print("H1Bdry:", tri.homologyBdry())
+		print("H1Rel:", tri.homologyRel())
+		print("H2:", tri.homologyH2())
+		print("H2Z2:", tri.homologyH2Z2(), "Z_2")
 	if tri.isValid() and tri.isClosed() and tri.countTetrahedra() > 0:
-		print "TV(5, 3) =", tri.turaevViro(5, 3)
+		print("TV(5, 3) =", tri.turaevViro(5, 3))
 
 		tv = tri.turaevViroApprox(5, 3)
 
@@ -98,51 +100,51 @@ def vitalStats(tri):
 
 		if tv < 0.00001 and tv > -0.00001:
 			tv = 0
-		print "TV(5, 3) ~ %.5f" % tv
+		print("TV(5, 3) ~ %.5f" % tv)
 
 	# Normal surface computations should only be run on sufficiently
 	# small triangulations, so as to keep the tests relatively fast.
 	if tri.countTetrahedra() < 7:
-		print "0-efficient:", tri.isZeroEfficient()
+		print("0-efficient:", tri.isZeroEfficient())
 		if tri.isConnected():
-			print "Splitting surface:", tri.hasSplittingSurface()
+			print("Splitting surface:", tri.hasSplittingSurface())
 
 	# Though this can use normal surfaces, its prechecks and
 	# optimisations should make it fast enough for our examples.
-	print "3-sphere:", tri.isThreeSphere()
+	print("3-sphere:", tri.isThreeSphere())
 
 	# Some of the following operations can create large triangulations,
 	# which give *lots* of output when we try to dump their face gluings
 	# and skeletal details.  We'd like to keep the output files small,
 	# so dump checksums of the details instead of the details themselves.
-	print "Double cover:"
+	print("Double cover:")
 	t = regina.Triangulation3(tri)
 	t.makeDoubleCover()
-	print "Checksum =", checksum(t.detail())
+	print("Checksum =", checksum(t.detail()))
 
-	print "Ideal to finite:"
+	print("Ideal to finite:")
 	t = regina.Triangulation3(tri)
-	print "Result =", t.idealToFinite()
-	print "Checksum =", checksum(t.detail())
+	print("Result =", t.idealToFinite())
+	print("Checksum =", checksum(t.detail()))
 
-	print "Finite to ideal:"
+	print("Finite to ideal:")
 	t = regina.Triangulation3(tri)
-	print "Result =", t.finiteToIdeal()
-	print "Checksum =", checksum(t.detail())
+	print("Result =", t.finiteToIdeal())
+	print("Checksum =", checksum(t.detail()))
 
-	print "Barycentric subdivision:"
+	print("Barycentric subdivision:")
 	t = regina.Triangulation3(tri)
 	t.barycentricSubdivision()
-	print "Checksum =", checksum(t.detail())
+	print("Checksum =", checksum(t.detail()))
 
-	print "Dehydration:", tri.dehydrate()
-	print "Isomorphism signature:", tri.isoSig()
-	print "Result of splitIntoComponents:", tri.splitIntoComponents()
+	print("Dehydration:", tri.dehydrate())
+	print("Isomorphism signature:", tri.isoSig())
+	print("Result of splitIntoComponents:", tri.splitIntoComponents())
 
 	if tri.detail() != old:
-		print "ERROR: Original triangulation has changed!"
+		print("ERROR: Original triangulation has changed!")
 
-	print
+	print()
 
 t = regina.Triangulation3()
 t.setLabel("Empty triangulation")

--- a/python/testsuite/utf8.test
+++ b/python/testsuite/utf8.test
@@ -31,69 +31,71 @@
 # Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 # MA 02110-1301, USA.
 
+from __future__ import print_function
+
 g = AbelianGroup()
 g.addRank(3)
-print g
-print g.str()
-print g.utf8()
-print g.detail()
+print(g)
+print(g.str())
+print(g.utf8())
+print(g.detail())
 g.addTorsionElement(17)
-print g
-print g.str()
-print g.utf8()
-print g.detail()
+print(g)
+print(g.str())
+print(g.utf8())
+print(g.detail())
 
 m = MatrixInt(2, 2)
 n = MatrixInt(2, 2)
 g = MarkedAbelianGroup(m, n)
-print g
-print g.str()
-print g.utf8()
-print g.detail()
+print(g)
+print(g.str())
+print(g.utf8())
+print(g.detail())
 n.set(0, 0, 23)
 g = MarkedAbelianGroup(m, n)
-print g
-print g.str()
-print g.utf8()
-print g.detail()
+print(g)
+print(g.str())
+print(g.utf8())
+print(g.detail())
 
 p = Polynomial()
 p[3] = -1
 p[1] = 4
 p[0] = -2
 p
-print p
-print p.str()
-print p.str('z')
-print p.utf8()
-print p.utf8('z')
+print(p)
+print(p.str())
+print(p.str('z'))
+print(p.utf8())
+print(p.utf8('z'))
 
 p = Cyclotomic(7)
 p[4] = 3
 p[1] = -1
 p
-print p
-print p.str()
-print p.str('z')
-print p.utf8()
-print p.utf8('z')
+print(p)
+print(p.str())
+print(p.str('z'))
+print(p.utf8())
+print(p.utf8('z'))
 
 p = Laurent(4)
 p[-3] = 2
 p
-print p
-print p.str()
-print p.str('z')
-print p.utf8()
-print p.utf8('z')
+print(p)
+print(p.str())
+print(p.str('z'))
+print(p.utf8())
+print(p.utf8('z'))
 
 p = Laurent2(-1, 2)
 p[0, -3] = 4
 p
-print p
-print p.str()
-print p.str('z')
-print p.str('z', 'w')
-print p.utf8()
-print p.utf8('z')
-print p.utf8('z', 'w')
+print(p)
+print(p.str())
+print(p.str('z'))
+print(p.str('z', 'w'))
+print(p.utf8())
+print(p.utf8('z'))
+print(p.utf8('z', 'w'))

--- a/python/utilities/CMakeLists.txt
+++ b/python/utilities/CMakeLists.txt
@@ -7,6 +7,7 @@ SET ( FILES
   intutils
   osutils
   pyutilities
+  registerIntFromPyIndex
   stringutils
   )
 

--- a/python/utilities/pyutilities.cpp
+++ b/python/utilities/pyutilities.cpp
@@ -35,6 +35,7 @@ void addLocale();
 void addBoolSet();
 void addOSUtils();
 void addStringUtils();
+void addRegisterIntFromPyIndex();
 
 void addUtilitiesClasses() {
     addIntUtils();
@@ -42,5 +43,6 @@ void addUtilitiesClasses() {
     addBoolSet();
     addOSUtils();
     addStringUtils();
+    addRegisterIntFromPyIndex();
 }
 

--- a/python/utilities/registerIntFromPyIndex.cpp
+++ b/python/utilities/registerIntFromPyIndex.cpp
@@ -1,0 +1,163 @@
+
+/**************************************************************************
+ *                                                                        *
+ *  Regina - A Normal Surface Theory Calculator                           *
+ *  Python Interface                                                      *
+ *                                                                        *
+ *  Copyright (c) 1999-2018, Ben Burton                                   *
+ *  For further details contact Ben Burton (bab@debian.org).              *
+ *                                                                        *
+ *  This program is free software; you can redistribute it and/or         *
+ *  modify it under the terms of the GNU General Public License as        *
+ *  published by the Free Software Foundation; either version 2 of the    *
+ *  License, or (at your option) any later version.                       *
+ *                                                                        *
+ *  As an exception, when this program is distributed through (i) the     *
+ *  App Store by Apple Inc.; (ii) the Mac App Store by Apple Inc.; or     *
+ *  (iii) Google Play by Google Inc., then that store may impose any      *
+ *  digital rights management, device limits and/or redistribution        *
+ *  restrictions that are required by its terms of service.               *
+ *                                                                        *
+ *  This program is distributed in the hope that it will be useful, but   *
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *  General Public License for more details.                              *
+ *                                                                        *
+ *  You should have received a copy of the GNU General Public             *
+ *  License along with this program; if not, write to the Free            *
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,       *
+ *  MA 02110-1301, USA.                                                   *
+ *                                                                        *
+ **************************************************************************/
+
+#include <boost/python.hpp>
+#include <boost/optional.hpp>
+
+using namespace boost::python;
+
+namespace regina {
+namespace python {
+
+template<typename T>
+struct register_int_from_py_index {
+
+    static
+    bool _in_range(const long value) {
+        if (not std::numeric_limits<T>::is_signed) {
+            if (value < 0) {
+                return false;
+            }
+        } else {
+            if (value < std::numeric_limits<T>::min()) {
+                return false;
+            }
+        }
+        if (value > std::numeric_limits<T>::max()) {
+            return false;
+        }
+        
+        return true;
+    }
+
+    static
+    boost::optional<T> _convert_py_int(PyObject * obj) {
+        if (PyInt_Check(obj)) {
+            // No error checking
+            const long value = PyInt_AS_LONG(obj);
+            if (_in_range(value)) {
+                return value;
+            }
+        }
+        
+        if (PyLong_Check(obj)) {
+            int overflow;
+            const long value = PyLong_AsLongAndOverflow(obj, &overflow);
+            if (overflow == 0) {
+                if (_in_range(value)) {
+                    return value;
+                }
+            }
+        }
+        
+        return boost::none;
+    }
+    
+    static
+    boost::optional<T> _convert_py_index(PyObject * const obj) {
+        if (not obj) {
+            return boost::none;
+        }
+        
+        PyObject * const attr = PyObject_GetAttrString(obj, "__index__");
+        if (not PyCallable_Check(attr)) {
+            return boost::none;
+        }
+        
+        PyObject * const args = PyTuple_New(0);
+        if (not args) {
+            return boost::none;
+        }
+        
+        PyObject * const result = PyObject_CallObject(attr, args);
+        Py_DECREF(args);
+        
+        if (not result) {
+            return boost::none;
+        }
+
+        const boost::optional<T> value = _convert_py_int(result);
+        
+        Py_DECREF(result);
+        
+        return value;
+    }
+    
+    static
+    void * convertible(PyObject * const obj) {
+        if (_convert_py_index(obj)) {
+            return obj;
+        }
+        
+        return nullptr;
+    }
+
+    using converter_data =
+        boost::python::converter::rvalue_from_python_stage1_data;
+    
+    static
+    void construct(PyObject * const obj,
+                   converter_data * const data) {
+
+        using converter_storage =
+            boost::python::converter::rvalue_from_python_storage<unsigned long>;
+        
+        void * const storage = ((converter_storage *) data)->storage.bytes;
+
+        if (const boost::optional<T> value = _convert_py_index(obj)) {
+            new (storage) T(*value);
+        } else {
+            new (storage) T(0);
+        }
+        
+        data->convertible = storage;
+    }
+
+    register_int_from_py_index() {
+        boost::python::converter::registry::push_back(
+            convertible,
+            construct,
+            boost::python::type_id<T>());
+    }
+};
+
+} } // namespace regina::python
+
+static
+void _registerIntFromPyIndex()
+{
+    regina::python::register_int_from_py_index<unsigned long>();
+}
+
+void addRegisterIntFromPyIndex() {
+    def("_registerIntFromPyIndex", &_registerIntFromPyIndex);
+}

--- a/python/utilities/registerIntFromPyIndex.cpp
+++ b/python/utilities/registerIntFromPyIndex.cpp
@@ -89,6 +89,7 @@ struct register_int_from_py_index {
     // the right type or the number is too big.
     static
     boost::optional<T> _convert_py_int(PyObject * obj) {
+        #if PY_MAJOR_VERSION < 3
         // Python 2 has two integer types, one holding a C long and
         // one holding arbitrary precision.
         if (PyInt_Check(obj)) {
@@ -97,6 +98,7 @@ struct register_int_from_py_index {
                 return value;
             }
         }
+        #endif
         
         if (PyLong_Check(obj)) {
             int overflow;

--- a/python/utilities/registerIntFromPyIndex.cpp
+++ b/python/utilities/registerIntFromPyIndex.cpp
@@ -206,6 +206,7 @@ static
 void _registerIntFromPyIndex()
 {
     regina::python::register_int_from_py_index<size_t>();
+    regina::python::register_int_from_py_index<int>();
 }
 
 void addRegisterIntFromPyIndex() {

--- a/python/utilities/registerIntFromPyIndex.cpp
+++ b/python/utilities/registerIntFromPyIndex.cpp
@@ -30,6 +30,20 @@
  *                                                                        *
  **************************************************************************/
 
+// Without the from-python conversion we register here, a user could
+// not type a command like "T.simplex(0)" into Sage. The reason is
+// that the Sage preparser turns it into "T.simplex(Integer(0))" where
+// Integer is a sage.rings.integer.Integer.
+//
+// Luckily, such an Integer follows PEP 357 and provides an __index__
+// method. This file implements a from-python conversion for integer types
+// checking whether the python object has an __index__ method returning an
+// integer.
+//
+// This conversion is not registered by default. It needs to be registered
+// explicitly with engine._registerIntFromPyIndex() in __init__.py when
+// we detect regina is run from sage.
+
 #include <boost/python.hpp>
 #include <boost/optional.hpp>
 
@@ -38,11 +52,22 @@ using namespace boost::python;
 namespace regina {
 namespace python {
 
+// from_python conversion of python objects implementing PEP 357 to integer
+// type T. Calling the c'tor will register the conversion with boost::python.
 template<typename T>
 struct register_int_from_py_index {
 
+    // Checks whether the given value can be held by the integer type T.
     static
     bool _in_range(const long value) {
+        // Note that value < std::numeric_limits<T>::min() is not working
+        // correctly when T is unsigned and has the same number of bits
+        // than value.
+        // This is because when comparing an unsigned and signed number with
+        // the same number of bits, C will interpret the signed number as
+        // unsigned number with the same number of bits, so the negative
+        // number becomes a really large unsigned number.
+        // Thus, we are branching here:
         if (not std::numeric_limits<T>::is_signed) {
             if (value < 0) {
                 return false;
@@ -59,10 +84,14 @@ struct register_int_from_py_index {
         return true;
     }
 
+    // Try to convert a python object to an integer of type T.
+    // Return empty boost::optional if python object is not holding
+    // the right type or the number is too big.
     static
     boost::optional<T> _convert_py_int(PyObject * obj) {
+        // Python 2 has two integer types, one holding a C long and
+        // one holding arbitrary precision.
         if (PyInt_Check(obj)) {
-            // No error checking
             const long value = PyInt_AS_LONG(obj);
             if (_in_range(value)) {
                 return value;
@@ -81,23 +110,32 @@ struct register_int_from_py_index {
         
         return boost::none;
     }
-    
+
+    // Get an integer from a python object by calling its __index__ method
     static
     boost::optional<T> _convert_py_index(PyObject * const obj) {
         if (not obj) {
             return boost::none;
         }
-        
+
+        // Check whether it has __index__
+        if (not PyObject_HasAttrString(obj, "__index__")) {
+            return boost::none;
+        }
+
+        // Get __index__
         PyObject * const attr = PyObject_GetAttrString(obj, "__index__");
         if (not PyCallable_Check(attr)) {
             return boost::none;
         }
-        
+
+        // Arguments for the call to __index__
         PyObject * const args = PyTuple_New(0);
         if (not args) {
             return boost::none;
         }
-        
+
+        // Call __index__
         PyObject * const result = PyObject_CallObject(attr, args);
         Py_DECREF(args);
         
@@ -105,13 +143,23 @@ struct register_int_from_py_index {
             return boost::none;
         }
 
+        // Extract integer from result of call
         const boost::optional<T> value = _convert_py_int(result);
         
         Py_DECREF(result);
         
         return value;
     }
-    
+
+    // Implements boost::python convertible concept.
+    //
+    // Note that we say it is not convertible if __index__ does not return
+    // an integer or the integer is too large. Thus, the user will see in
+    // these cases the typical boost message that the signature did not
+    // match. It might be better, if we actually threw an exception and
+    // gave a python error similar to what, e.g., range(10)[f] does if
+    // f.__index__ returned a non-int:
+    //    TypeError: __index__ returned non-(int,long) (type str)
     static
     void * convertible(PyObject * const obj) {
         if (_convert_py_index(obj)) {
@@ -123,7 +171,8 @@ struct register_int_from_py_index {
 
     using converter_data =
         boost::python::converter::rvalue_from_python_stage1_data;
-    
+
+    // Implements boost::python constructing a C++ int from a python object
     static
     void construct(PyObject * const obj,
                    converter_data * const data) {
@@ -142,6 +191,7 @@ struct register_int_from_py_index {
         data->convertible = storage;
     }
 
+    // Registers the from_python conversion
     register_int_from_py_index() {
         boost::python::converter::registry::push_back(
             convertible,
@@ -155,7 +205,7 @@ struct register_int_from_py_index {
 static
 void _registerIntFromPyIndex()
 {
-    regina::python::register_int_from_py_index<unsigned long>();
+    regina::python::register_int_from_py_index<size_t>();
 }
 
 void addRegisterIntFromPyIndex() {


### PR DESCRIPTION
When inside sage, "from regina import *" will not override Sage's Integer anymore. This was wracking havoc in conjunction with the sage preprocessor.
When run inside sage, there will be a conversion from object's with an __index__ method (see PEP 357) to size_t. This way, the user can type "T.simplex(0)" without getting an error.