### PR TITLE
Python 3 compatibility: print statements need parens

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,7 +480,7 @@ IF(Boost_FOUND AND PYTHONINTERP_FOUND AND PYTHONLIBS_FOUND)
   # Find the site-packages location in which the XDG build needs to put
   # the python module.
   EXECUTE_PROCESS(COMMAND
-    "${PYTHON_EXECUTABLE}" -c "import distutils.sysconfig; print distutils.sysconfig.get_python_lib(True)"
+    "${PYTHON_EXECUTABLE}" -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(True))"
     OUTPUT_VARIABLE SITE_PACKAGES
     OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE DISTUTILS_RESULT)

--- a/python/regina/__init__.py
+++ b/python/regina/__init__.py
@@ -118,7 +118,7 @@ def reginaSetup(quiet = False, readline = True, banner = False,
                     sys.path.append(snappyLib + '/lib-dynload')
 
     if banner:
-        print engine.welcome()
+        print(engine.welcome())
 
     if builtinOpen and namespace:
         namespace['open'] = __builtins__['open']


### PR DESCRIPTION
Still works fine with Python 2, of course.