### PR TITLE
Adds overrided __or__ to flags

### DIFF
--- a/python/surfaces/normalflags.cpp
+++ b/python/surfaces/normalflags.cpp
@@ -49,7 +49,9 @@ void addNormalFlags(pybind11::module& m) {
         .value("NS_FUNDAMENTAL", regina::NS_FUNDAMENTAL)
         .value("NS_LEGACY", regina::NS_LEGACY)
         .value("NS_CUSTOM", regina::NS_CUSTOM)
-        .export_values();
+        .export_values()
+        .def("__or__", [](const NormalListFlags& lhs, const NormalListFlags& rhs){
+                return NormalList(lhs) | rhs;});
 
     auto l = pybind11::class_<NormalList>(m, "NormalList")
         .def(pybind11::init<>())
@@ -93,7 +95,9 @@ void addNormalFlags(pybind11::module& m) {
         .value("NS_HILBERT_FULLCONE", regina::NS_HILBERT_FULLCONE)
         .value("NS_ALG_LEGACY", regina::NS_ALG_LEGACY)
         .value("NS_ALG_CUSTOM", regina::NS_ALG_CUSTOM)
-        .export_values();
+        .export_values()
+        .def("__or__", [](const NormalAlgFlags& lhs, const NormalAlgFlags& rhs){
+                return NormalAlg(lhs) | rhs;});
 
     auto a = pybind11::class_<NormalAlg>(m, "NormalAlg")
         .def(pybind11::init<>())


### PR DESCRIPTION
This addresses #51 by creating an __or__ operator for each of
the enums to promote the left hand side to NormalList/NormalAlg
respectively. This lines up with the engine, where only the `or` operator
promotes. Note that using pybind11::self | pybind11::self does not
compile (not sure on exact reason), and the .def has to come after
export_values(), as otherwise it demotes the pybind11::enum down to a
pybind11::class which means it loses access to export_values().
