### PR TITLE
Correct the header too

### DIFF
--- a/engine/census/census.h
+++ b/engine/census/census.h
@@ -478,7 +478,7 @@ class REGINA_API Census {
             /**< The census of cusped hyperbolic non-orientable 3-manifold
                  triangulations that are shipped with Regina.
                  This will only be initialised when lookup() is first called. */
-        static CensusDB* hypKnotLink_;
+        static CensusDB* knotLink_;
             /**< The census of cusped hyperbolic knot and link complements
                  that are shipped with Regina.
                  This will only be initialised when lookup() is first called. */


### PR DESCRIPTION
There is currently missmatch of implemnetation and the header
w.r.t. dropped 'hyp' prefix from knotLink.

Fixes c947ac0147ca83a359797f6bb1e1fda0127863a2
Fixes #45