### PR TITLE
Add GH Action to build/test

### DIFF
--- a/.github/workflows/compile-build-test.yml
+++ b/.github/workflows/compile-build-test.yml
@@ -1,0 +1,21 @@
+name: Compile and test
+on:
+    push:
+        branches:
+            - 'master'
+jobs:
+    compile-ubuntu:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install pre-reqs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get -y install libgmp-dev libxml2-dev libjansson-dev libtokyocabinet-dev libpopt-dev qtbase5-dev libqt5svg5-dev python3-all-dev doxygen libgraphviz-dev pkg-config xsltproc libcppunit-dev
+            - name: Configure
+              run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+            - name: Compile
+              run: cmake --build build --target all --config Release -- -j4
+            - name: Test
+              run: ctest
+


### PR DESCRIPTION
Using Github actions to automate compiles+tests could be useful for spotting unexpected bugs. However! There is an added need to keep the `apt-get install` line in `compile-build-test.yml` up to date with any new dependencies.

Example run can be seen at https://github.com/WPettersson/regina-1/actions/runs/1842524590